### PR TITLE
Added support for named datapoints (hashes) in series data

### DIFF
--- a/lib/highcharts/series.rb
+++ b/lib/highcharts/series.rb
@@ -2,7 +2,19 @@ class Highcharts
   class Series < Base
 
     def to_json
-      @options[:data] = options[:data].first.is_a?(Array) ? options[:data].collect {|d| [d.first, d.last.to_f]} : options[:data].collect(&:to_f)
+      @options[:data] = if options[:data].first.is_a?(Array) || options[:data].first.is_a?(Hash)
+        options[:data].collect do |d|
+          if d.is_a?(Array)
+            [d.first, d.last.to_f]
+          else
+            d[:y] = d[:y].to_f
+            d
+          end
+        end
+      else
+        options[:data].collect(&:to_f)
+      end
+
       super
     end
 


### PR DESCRIPTION
I have add support for named datapoints (hashes) in series data as described in  Highcharts API
http://api.highcharts.com/highcharts#series.data  as 3rd method:

Example:

```
chart = Highcharts.new
chart.series([
  :data => [
    {name: 'Point 1', color: '#00FF00', y: 0}, 
    {name: 'Point 2', color: '#FF00FF', y: 5}
  ]
])
```
